### PR TITLE
Fix types to work with the runtime emulator.

### DIFF
--- a/lambda-http/src/body.rs
+++ b/lambda-http/src/body.rs
@@ -25,8 +25,8 @@ use serde::ser::{Error as SerError, Serialize, Serializer};
 /// text produce `Body::Text` variants
 ///
 /// ```
-/// assert!(match lambda_http::Body::from("text") {
-///   lambda_http::Body::Text(_) => true,
+/// assert!(match netlify_lambda_http::Body::from("text") {
+///   netlify_lambda_http::Body::Text(_) => true,
 ///   _ => false
 /// })
 /// ```
@@ -36,8 +36,8 @@ use serde::ser::{Error as SerError, Serialize, Serializer};
 /// Types like `Vec<u8>` and `&[u8]` whose types reflect raw bytes produce `Body::Binary` variants
 ///
 /// ```
-/// assert!(match lambda_http::Body::from("text".as_bytes()) {
-///   lambda_http::Body::Binary(_) => true,
+/// assert!(match netlify_lambda_http::Body::from("text".as_bytes()) {
+///   netlify_lambda_http::Body::Binary(_) => true,
 ///   _ => false
 /// })
 /// ```
@@ -49,8 +49,8 @@ use serde::ser::{Error as SerError, Serialize, Serializer};
 /// The unit type ( `()` ) whose type represents an empty value produces `Body::Empty` variants
 ///
 /// ```
-/// assert!(match lambda_http::Body::from(()) {
-///   lambda_http::Body::Empty => true,
+/// assert!(match netlify_lambda_http::Body::from(()) {
+///   netlify_lambda_http::Body::Empty => true,
 ///   _ => false
 /// })
 /// ```

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -69,13 +69,13 @@ pub enum LambdaRequest<'a> {
     #[serde(rename_all = "camelCase")]
     ApiGateway {
         path: Cow<'a, str>,
-        #[serde(deserialize_with = "deserialize_method")]
+        #[serde(default, deserialize_with = "deserialize_method")]
         http_method: http::Method,
-        #[serde(deserialize_with = "deserialize_headers")]
+        #[serde(default, deserialize_with = "deserialize_headers")]
         headers: http::HeaderMap,
         #[serde(default, deserialize_with = "deserialize_multi_value_headers")]
         multi_value_headers: http::HeaderMap,
-        #[serde(deserialize_with = "nullable_default")]
+        #[serde(default, deserialize_with = "nullable_default")]
         query_string_parameters: StrMap,
         #[serde(default, deserialize_with = "nullable_default")]
         multi_value_query_string_parameters: StrMap,
@@ -116,6 +116,7 @@ pub enum RequestOrigin {
     Alb,
 }
 
+/// Represents the request context for ApiGateway V2
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2RequestContext {
@@ -449,7 +450,7 @@ impl<'a> From<LambdaRequest<'a>> for http::Request<Body> {
                             headers
                                 .get(http::header::HOST)
                                 .and_then(|val| val.to_str().ok())
-                                .unwrap_or_default(),
+                                .unwrap_or_else(|| "localhost"),
                             path
                         )
                     })

--- a/lambda/src/types.rs
+++ b/lambda/src/types.rs
@@ -128,14 +128,16 @@ impl TryFrom<HeaderMap> for Context {
                 .to_str()?
                 .parse()
                 .expect("Missing deadline"),
-            invoked_function_arn: headers["lambda-runtime-invoked-function-arn"]
-                .to_str()
-                .expect("Missing arn; this is a bug")
-                .to_owned(),
-            xray_trace_id: headers["lambda-runtime-trace-id"]
-                .to_str()
-                .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
-                .to_owned(),
+            invoked_function_arn: headers
+                .get("lambda-runtime-invoked-function-arn")
+                .and_then(|h| h.to_str().ok())
+                .map(str::to_owned)
+                .unwrap_or_default(),
+            xray_trace_id: headers
+                .get("lambda-runtime-trace-id")
+                .and_then(|h| h.to_str().ok())
+                .map(str::to_owned)
+                .unwrap_or_default(),
             ..Default::default()
         };
         Ok(ctx)


### PR DESCRIPTION
- Use localhost as default host.
- Allow missing context headers. They are optional, but we leave the context type declaration as is to keep backwards compatibility.
- Allow more default fields in api gateway requests.

Signed-off-by: David Calavera <david.calavera@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
